### PR TITLE
fix sidebar UI bug in readonly_note_page.

### DIFF
--- a/src/main/java/controller/groups/ReadOnlyGroupController.java
+++ b/src/main/java/controller/groups/ReadOnlyGroupController.java
@@ -1,0 +1,528 @@
+package controller.groups;
+
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.*;
+import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+import model.*;
+import model.selected.SelectedGroup;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import utils.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static utils.GroupServices.findGroupById;
+import static utils.GroupServices.updateGroup;
+
+public class ReadOnlyGroupController {
+
+
+    // group detail
+//    @FXML
+//    private Button editGroupBtn;
+
+//    @FXML
+////    private TextField groupDescInput;
+
+//    @FXML
+//    private TextField groupNameInput;
+
+
+    //sidebar
+    @FXML
+    private Button myNotesBtn;
+    @FXML
+    private Button shareNotesBtn;
+    @FXML
+    private Button myGroupsBtn;
+    @FXML
+    private Button allGroupsBtn;
+    @FXML
+    private Button accountBtn;
+    @FXML
+    private Button logOutBtn;
+
+
+    // header
+    @FXML
+    private Label nameLabel;
+    @FXML
+    private Label localTime;
+
+    @FXML
+    private BorderPane root;
+
+    @FXML
+    private Label editedGroupNameid;
+
+    @FXML
+    private Label membersInGroup;
+
+    @FXML
+    private Label notiLabel1;
+
+    @FXML
+    private Label editedGroupNameLabel;
+    @FXML
+    private Label editedGroupDescLabel;
+
+    @FXML
+    private Label groupNameLabel;
+    @FXML
+    private Label groupDescLabel;
+
+
+    @FXML
+    private TableView<AppUser> table1;
+
+    @FXML
+    private TableColumn<AppUser, String> group1;  // Username column
+    @FXML
+    private TableColumn<AppUser, String> category1;  // Email column
+
+    private ObservableList<AppUser> groupMembers = FXCollections.observableArrayList();
+
+    private Group group;
+    private Stage stage;
+    private Scene scene;
+    private Parent parent;
+    private ControllerUtils controllerUtils;
+    private List<AppUser> memberList;
+
+    SelectedGroup selectedGroup = SelectedGroup.getInstance();
+    private HttpResponseService httpResponseService;
+//    private HttpClientSingleton httpInstance;
+
+    TableColumn<AppUser, AppUser> actionOneCol;
+
+    private String getGroupUri() {
+        int groupId = selectedGroup.getId();
+        return "http://localhost:8093/api/groups/" + groupId;
+    }
+
+    String URI = getGroupUri();
+    private static final String FXMLSource = "/fxml";
+    private static final String CSSSOURCE = "/CSS";
+
+    public JSONArray convertToJSONArray(List<GroupMember> groupMembers) {
+        JSONArray jsonArray = new JSONArray();
+        for (GroupMember member : groupMembers) {
+            JSONObject memberObject = new JSONObject();
+            memberObject.put("id", member.getId());
+            memberObject.put("username", member.getUsername());
+            memberObject.put("email", member.getEmail());
+            jsonArray.put(memberObject);
+        }
+        return jsonArray;
+    }
+
+
+    public void initialize() {
+        this.memberList = new ArrayList<>();
+
+        System.out.println("Start Edit Group Page");
+        System.out.println("scene " + scene);
+        this.controllerUtils = new ControllerUtils();
+        this.httpResponseService = new HttpResponseServiceImpl();
+
+        // Fetch the group from the server
+        Group group = findGroupById("http://localhost:8093/api/groups/", selectedGroup.getId(), TokenStorage.getToken());
+
+        System.out.println("Group is " + group);
+        System.out.println("Fetching group with ID: " + selectedGroup.getId());
+
+        if (group != null) {
+//            groupNameInput.setText(group.getName());
+//            groupDescInput.setText(group.getDescription());
+            groupNameLabel.setText(group.getName());
+            groupDescLabel.setText(group.getDescription());
+        } else {
+            System.out.println("Group not found.");
+
+        }
+
+        TokenStorage.getIntance();
+        String username = TokenStorage.getUser();
+        String password = TokenStorage.getToken();
+        System.out.println("User: " + TokenStorage.getUser() + ", token: " + TokenStorage.getToken());
+
+        nameLabel.setText("Welcome " + username);
+        MainPageServices.updateLocalTime(localTime);
+
+        root.getStylesheets().add(getClass().getResource(CSSSOURCE + "/button.css").toExternalForm());
+        root.getStylesheets().add(getClass().getResource(CSSSOURCE + "/text_input.css").toExternalForm());
+
+//        editGroupBtn.getStylesheets().add(getClass().getResource(CSSSOURCE + "/groups.css").toExternalForm());
+        ControllerUtils_v2.addStyle(logOutBtn,"/logout-button.css");
+
+
+        table1.setItems(groupMembers);
+
+        // create action column with default button
+        actionOneCol = addAppUserCol("Action");
+
+        // update Table View with updated action button
+        // 1. get group based on ID and its member list
+        // 2. update user table with the groups's member list
+        // 3. update the button in the user table based on the member role
+        getGroupUserInfoByGroupId();
+        //        updateTableView();
+        // Optional: You can refresh the table or set listeners here if necessary
+        //setUpTableListeners();
+    }
+
+    public void getGroupUserInfoByGroupId() {
+        String ALL_GROUP_URI = URI;
+        HttpRequestBuilder httpRequestBuilder = new HttpRequestBuilder("GET", ALL_GROUP_URI, true);
+        HttpRequestBase request = httpRequestBuilder.getHttpRequest();
+        CloseableHttpClient httpClient = httpRequestBuilder.getHttpClient();
+        httpResponseService.handleReponse(request, httpClient, this::handleGroupUserInfoByGroupId);
+//        return null;
+    }
+
+    public void handleGroupUserInfoByGroupId(CloseableHttpResponse response, Object jsonResponse) {
+        List<Group> updatedAllGroups = new ArrayList<>();
+        JSONObject groupObject = controllerUtils.toJSonObject(jsonResponse);
+        System.out.println("Group Object " + groupObject);
+//        System.out.println(array);
+//               System.out.println(groupObject);
+        JSONObject owner = (JSONObject) ((JSONObject) groupObject).get("owner");
+        String ownerEmail = owner.getString("email");
+        GroupOwner groupOwner = new GroupOwner((int) owner.get("id"), (String) owner.get("username"), ownerEmail);
+        int id = (int) ((JSONObject) groupObject).get("id");
+        String name = (String) ((JSONObject) groupObject).get("name");
+        String description = (String) ((JSONObject) groupObject).get("description");
+        JSONArray userListObj = (JSONArray) ((JSONObject) groupObject).get("userGroupParticipationsList");
+        AppUser currentOwner = new AppUser((int) owner.get("id"), (String) owner.get("username"), ownerEmail);
+        List<AppUser> userList = createUserList(userListObj);
+        userList.add(currentOwner);
+
+        this.group = new Group(id, name, description, groupOwner, userList);
+
+
+        System.out.println("Current Owner " + currentOwner);
+
+        System.out.println("User list " + userList);
+        //updatedAllGroups.add(newGroup);
+        this.memberList = this.group.getUserList();
+
+        System.out.println("Member List " + memberList);
+        // setup, display data to table with processed data
+        displayUserTable();
+        updateColumnOne();
+    }
+
+    private List<AppUser> createUserList(JSONArray userObjectArray) {
+        List<AppUser> userList = new ArrayList<>();
+        for (Object userObject : userObjectArray) {
+            JSONObject converted = (JSONObject) userObject;
+            int id = (int) converted.get("id");
+            String name = (String) converted.get("username");
+            String email = (String) converted.get("email");
+            userList.add(new AppUser(id, name, email));
+        }
+        return userList;
+    }
+
+    public void displayUserTable() {
+
+//        idCol.setCellValueFactory(new PropertyValueFactory<>("Id"));
+        // group1 í column name, "Name" is the property name of the AppUser
+        group1.setCellValueFactory(new PropertyValueFactory<>("Username"));
+//        System.out.println("name: "+ group1.getCellValueFactory().equals(TokenStorage.getUser()));
+        category1.setCellValueFactory(new PropertyValueFactory<>("Email"));
+//        numOfMembersCol.setCellValueFactory(new PropertyValueFactory<>("NumberOfMembers"));
+
+        groupMembers = FXCollections.observableArrayList(this.memberList);
+        table1.setItems(groupMembers);
+        transformUsername();
+//        table1.getItems();
+    }
+
+
+    public boolean isOwner(String username) {
+        String loginnedUsername = TokenStorage.getUser();
+        String formattedUsername = "owner - " + loginnedUsername;
+
+        return username.equals(loginnedUsername) || username.equals(formattedUsername);
+    }
+
+    public void transformUsername() {
+        System.out.println("Items: " + table1.getItems().getClass());
+        List<AppUser> curMemberList = table1.getItems();
+        String logginedUsername = TokenStorage.getUser();
+        for (AppUser user : curMemberList) {
+            String username = user.getUsername();
+            System.out.println(user);
+            if (username.equals(logginedUsername)) {
+                user.setUsername("owner - " + username);
+            }
+            System.out.println(user);
+        }
+    }
+
+    public void handleGetGroupUserId(CloseableHttpResponse response, Object jsonResponse) {
+        JSONObject object = controllerUtils.toJSonObject(jsonResponse);
+        try {
+            System.out.println(object);
+            String email = (String) object.get("email");
+            String username = (String) object.get("username");
+            group1.setText(email);
+            category1.setText(username);
+        } catch (JSONException e) {
+            System.out.println("Error parsing JSON: " + e.getMessage());
+        }
+    }
+
+
+    public TableColumn<AppUser, AppUser> addAppUserCol(String columnName) {
+        int TABLE_CELL_WIDTH = 100;
+        TableColumn<AppUser, AppUser> column = ViewUtils.column(columnName, ReadOnlyObjectWrapper<AppUser>::new, TABLE_CELL_WIDTH);
+
+        table1.getColumns().add(column);
+        column.setCellFactory(col -> {
+            Button editButton = new Button(columnName);
+            TableCell<AppUser, AppUser> cell = new TableCell<AppUser, AppUser>() {
+                @Override
+                public void updateItem(AppUser person, boolean empty) {
+                    super.updateItem(person, empty);
+                    if (empty) {
+                        setGraphic(null);
+                    } else {
+                        setGraphic(editButton);
+                    }
+                }
+            };
+
+            editButton.setOnAction(e -> System.out.println("click edit button for: " + cell.getItem()));
+            return cell;
+        });
+        return column;
+    }
+
+    private void updateColumnOne() {
+        String owner = TokenStorage.getUser();
+        String groupOwner = this.group.getGroupOwnerName();
+        System.out.println("Group Owner: " + groupOwner);
+        System.out.println("Loggined user: " + owner);
+
+
+//        String fName = "Jacob";
+        actionOneCol.setCellFactory(col -> {
+            Button editButton = new Button("Edit");
+            Button removeButton = new Button("Remove");
+//            Button joinButton = new Button("Join");
+            TableCell<AppUser, AppUser> updatedCell = new TableCell<AppUser, AppUser>() {
+                @Override
+                // display button
+                public void updateItem(AppUser appUser, boolean empty) {
+                    super.updateItem(appUser, empty);
+                    // if data is null, add no button
+                    if (empty) {
+                        setGraphic(null);
+                    } else {
+                        // if loggined user != group owner
+//                        if (!owner.equals(groupOwner)) {
+                        if (!owner.equals(groupOwner)) {
+                            setGraphic(null);
+                        } else {
+                            // if current member is the same as loggined user
+//                            if (owner.equals(appUser.getUsername())) {
+                            if (isOwner(appUser.getUsername())) {
+//                            setGraphic(null);
+                                setGraphic(editButton);
+                                ViewUtils.addStyle(editButton, "/edit-button.css");
+                                // if current member is not the loggined user
+                            } else {
+//                            setGraphic(null);
+                                setGraphic(removeButton);
+                                ViewUtils.addStyle(removeButton, "/delete-button.css");
+                            }
+                        }
+                    }
+                }
+            };
+            // updatedCell.getItem() == group object
+            //edit my own info
+            editButton.setOnAction(e -> {
+                Button source = (Button) e.getSource();
+                System.out.println("is button " + source);
+                editAccountInfo(source);
+                //                edit(updatedCell.getItem(), (source));
+            });
+
+            removeButton.setOnAction((e -> {
+                Button source = (Button) e.getSource();
+                System.out.println("is button " + source);
+                System.out.println(updatedCell.getItem());
+                removeUser(updatedCell.getItem());
+            }));
+
+
+            this.controllerUtils.setDefaultAndHandCursorBehaviour(removeButton);
+            this.controllerUtils.setDefaultAndHandCursorBehaviour(editButton);
+            return updatedCell;
+
+        });
+    }
+
+    public void editAccountInfo(Button btn) {
+        String FXMLString = "/fxml/main_pages/account_user_info_page.fxml";
+
+        selectedGroup.setId(group.getId());
+        controllerUtils.goPage(stage, btn, FXMLString);
+    }
+
+    public void removeUser(AppUser appUser) {
+        System.out.println("delete group");
+        int appUserId = appUser.getId();
+        String REMOVE_URI = URI + "/remove/" + appUserId;
+        System.out.println(REMOVE_URI);
+        HttpRequestBuilder httpRequestBuilder = new HttpRequestBuilder("DELETE", REMOVE_URI, true);
+        HttpRequestBase request = httpRequestBuilder.getHttpRequest();
+        CloseableHttpClient httpClient = httpRequestBuilder.getHttpClient();
+        httpResponseService.handleReponse(request, httpClient, this::handleRemoveUser);
+    }
+
+    public void handleRemoveUser(CloseableHttpResponse response, Object object) {
+        System.out.println("response " + response);
+//        updateTableView();
+        // get a updated group info from database after remove member
+        getGroupUserInfoByGroupId();
+    }
+
+//    @FXML
+//    void accountBtnClick() {
+//
+//    }
+//
+//    @FXML
+//    void allGroupsBtnClick() {
+//        String pageLink = "/fxml/main_pages/groups/group_info_create_group.fxml";
+//        this.controllerUtils.goPage(stage, editGroupBtn, pageLink);
+//    }
+
+//    @FXML
+//    void editGroupBtnClick() {
+//        // Get edited values
+//        String editedGroupName = groupNameInput.getText();
+//        String editedDescInput = groupDescInput.getText();
+//        int groupId = selectedGroup.getId();
+//
+//        System.out.println("Edited group name: " + editedGroupName);
+//        System.out.println("Edited group description: " + editedDescInput);
+//        System.out.println("Edit button clicked!");
+//
+//        // Create JSON request body
+//
+//        System.out.println("Group Id 8/3 " + groupId);
+//        JSONObject jsonRequest = new JSONObject();
+//        jsonRequest.put("id", groupId);
+//        jsonRequest.put("name", editedGroupName);
+//        jsonRequest.put("description", editedDescInput);
+//
+//        // Send update request
+//        boolean updateSuccess = updateGroup("http://localhost:8093/api/groups/", groupId, jsonRequest.toString(), TokenStorage.getToken());
+//
+//        System.out.println("Group ID at update success for edit group " + groupId);
+//
+//        if (updateSuccess) {
+//            notiLabel1.setText("You've successfully edited group information.");
+//            editedGroupNameLabel.setText("Edited group name: " + editedGroupName);
+//            editedGroupDescLabel.setText("Edited group description: " + editedDescInput);
+//            //refreshGroupList();
+//            //controllerUtils.goPage(stage, button, FXMLString);
+//        } else {
+//            notiLabel1.setText("Failed to edit group. Please try again.");
+//        }
+//    }
+
+/*    private void refreshGroupList() {
+        // Fetch updated group from the server
+        Group updatedGroup = findGroupById("http://localhost:8093/api/groups/", selectedGroup.getId(), TokenStorage.getToken());
+
+        if (updatedGroup != null) {
+            // Update UI fields
+            groupNameInput.setText(updatedGroup.getName());
+            groupDescInput.setText(updatedGroup.getDescription());
+
+            // Update the TableView with the latest members
+            groupMembers.clear();
+            groupMembers.addAll(updatedGroup.getMembers()); // Ensure Group class has `getMembers()`
+
+            table1.refresh();  // Refresh TableView UI
+        } else {
+            System.out.println("Failed to refresh group details.");
+        }
+    }*/
+
+    //sidebar
+    public void myGroupsBtnClick() {
+//        this.controllerUtils.goPage(stage, myGroupsBtn, "/fxml/main_pages/groups/my_groups.fxml");
+        ControllerUtils_v2.goToMyGroupsPage(stage, myGroupsBtn);
+    }
+
+    @FXML
+    public void myNotesBtnClick() {
+
+//        this.controllerUtils.goPage(stage, myNotesBtn, "/fxml/main_pages/main_page.fxml");
+        ControllerUtils_v2.goToMyNotesPage(stage, myNotesBtn);
+    }
+
+    @FXML
+    public void shareNotesBtnClick() {
+//        this.controllerUtils.goPage(stage,shareNoteBtn,"");
+        System.out.println("Go to share notes page");
+//        this.controllerUtils.goPage(stage, allGroupsBtn, "/fxml/main_pages/groups/my_groups_notes.fxml");
+        ControllerUtils_v2.goToMyGroupNotesPage(stage, shareNotesBtn);
+    }
+
+    @FXML
+    public void allGroupsBtnClick() {
+//        this.controllerUtils.goPage(stage, allGroupsBtn, "/fxml/main_pages/groups/all_groups.fxml");
+        ControllerUtils_v2.goToAllGroupsPage(stage, allGroupsBtn);
+    }
+
+    @FXML
+    public void accountBtnClick() {
+//        this.controllerUtils.goPage(stage, accountBtn, "/fxml/main_pages/account_user_info_page.fxml");
+        ControllerUtils_v2.goToAccountPage(stage, accountBtn);
+    }
+
+    @FXML
+    public void logOutBtnClick() {
+        this.controllerUtils.logout(stage, logOutBtn);
+    }
+
+    @FXML
+    void mouseEnter() {
+        this.controllerUtils.setHandCursor(myNotesBtn);
+        this.controllerUtils.setHandCursor(shareNotesBtn);
+        this.controllerUtils.setHandCursor(myGroupsBtn);
+        this.controllerUtils.setHandCursor(allGroupsBtn);
+        this.controllerUtils.setHandCursor(accountBtn);
+        this.controllerUtils.setHandCursor(logOutBtn);
+    }
+
+    @FXML
+    void mouseExit() {
+        this.controllerUtils.setDefaultCursor(myNotesBtn);
+        this.controllerUtils.setDefaultCursor(shareNotesBtn);
+        this.controllerUtils.setDefaultCursor(myGroupsBtn);
+        this.controllerUtils.setDefaultCursor(allGroupsBtn);
+        this.controllerUtils.setDefaultCursor(accountBtn);
+        this.controllerUtils.setDefaultCursor(logOutBtn);
+    }
+}

--- a/src/main/java/utils/GroupControllerUtils.java
+++ b/src/main/java/utils/GroupControllerUtils.java
@@ -111,6 +111,7 @@ public class GroupControllerUtils {
                 ;
             });
             ControllerUtils_v2.setDefaultAndHandCursorBehaviour(editButton);
+            ControllerUtils_v2.setDefaultAndHandCursorBehaviour(viewButton);
             return updatedCell;
 
         });

--- a/src/main/java/utils/GroupControllerUtils.java
+++ b/src/main/java/utils/GroupControllerUtils.java
@@ -73,6 +73,7 @@ public class GroupControllerUtils {
 //        String fName = "Jacob";
         actionOneCol.setCellFactory(col -> {
             Button editButton = new Button("Edit");
+            Button viewButton = new Button ("View");
 //            Button joinButton = new Button("Join");
             TableCell<Group, Group> updatedCell = new TableCell<Group, Group>() {
                 @Override
@@ -85,7 +86,12 @@ public class GroupControllerUtils {
                         if (owner.equals(group.getGroupOwner().getUsername())) {
                             setGraphic(editButton);
                             ViewUtils.addStyle(editButton, "/edit-button.css");
-                        } else {
+                        } else if (group.isExist(owner) &&  (!group.getGroupOwner().equals(owner))) {
+                            System.out.println("Owner: "+owner+ "is in group: "+group.getName());
+                            setGraphic(viewButton);
+                            ViewUtils.addStyle(viewButton, "/delete-button.css");
+                        }
+                        else {
                             setGraphic(null);
                         }
                     }
@@ -96,7 +102,13 @@ public class GroupControllerUtils {
             editButton.setOnAction(e -> {
                 Button source = (Button) e.getSource();
                 System.out.println("is button " + source);
-                edit(stage, updatedCell.getItem(), (source));
+                edit(stage, updatedCell.getItem(), source);
+            });
+            viewButton.setOnAction( e-> {
+                Button source = (Button) e.getSource();
+                System.out.println("is button " + source+", view button click");
+                view(stage, updatedCell.getItem(), source)
+                ;
             });
             ControllerUtils_v2.setDefaultAndHandCursorBehaviour(editButton);
             return updatedCell;
@@ -165,6 +177,13 @@ public class GroupControllerUtils {
             return updatedCell;
 
         });
+    }
+
+    public static void view(Stage stage, Group group, Button button){
+        String pageLink = "/fxml/main_pages/groups/readonly_group_page.fxml";
+        SelectedGroup selectedGroup = SelectedGroup.getInstance();
+        selectedGroup.setId(group.getId());
+        ControllerUtils_v2.goPage(stage, button, pageLink);
     }
 
     public static void edit(Stage stage, Group group, Button button) {

--- a/src/main/resources/fxml/main_pages/groups/readonly_group_page.fxml
+++ b/src/main/resources/fxml/main_pages/groups/readonly_group_page.fxml
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.shape.SVGPath?>
+<?import javafx.scene.text.Font?>
+
+<BorderPane id="parent" fx:id="root" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" style="-fx-background-color: #FFFFFF;" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controller.groups.ReadOnlyGroupController">
+   <left>
+      <VBox alignment="TOP_CENTER" focusTraversable="true" styleClass="side-bar" stylesheets="@../../../CSS/side_bar.css" BorderPane.alignment="TOP_CENTER">
+         <children>
+            <ImageView fitHeight="70.0" fitWidth="220.0" pickOnBounds="true" preserveRatio="true" VBox.vgrow="ALWAYS">
+               <image>
+                  <Image url="@../../../img/logo/logo1.png" />
+               </image>
+               <VBox.margin>
+                  <Insets bottom="40.0" top="40.0" />
+               </VBox.margin>
+            </ImageView>
+            <Button fx:id="myNotesBtn" graphicTextGap="10.0" minHeight="50.0" minWidth="200.0" mnemonicParsing="false" onMouseClicked="#myNotesBtnClick" onMouseEntered="#mouseEnter" onMouseExited="#mouseExit" stylesheets="@../../../CSS/button.css" text="My notes" VBox.vgrow="ALWAYS">
+               <font>
+                  <Font size="16.0" />
+               </font>
+               <opaqueInsets>
+                  <Insets />
+               </opaqueInsets>
+               <graphic>
+                  <AnchorPane prefHeight="24.0" prefWidth="24.0">
+                     <children>
+                        <SVGPath content="M12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22Z" fill="WHITE" stroke="#898989" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="2.0" styleClass="icon" />
+                        <SVGPath content="M13.5 8C10.47 8 8 10.48 8 13.5C8 14.87 9.12 16 10.5 16C13.52 16 16 13.52 16 10.5C16 9.13 14.87 8 13.5 8Z" fill="WHITE" stroke="#898989" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="2.0" styleClass="icon" />
+                     </children>
+                  </AnchorPane>
+               </graphic>
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+            </Button>
+            <Button fx:id="shareNotesBtn" graphicTextGap="10.0" minHeight="50.0" minWidth="200.0" mnemonicParsing="false" onMouseClicked="#shareNotesBtnClick" onMouseEntered="#mouseEnter" onMouseExited="#mouseExit" stylesheets="@../../../CSS/button.css" text="My Groups' Notes" VBox.vgrow="ALWAYS">
+               <font>
+                  <Font size="16.0" />
+               </font>
+               <opaqueInsets>
+                  <Insets />
+               </opaqueInsets>
+               <graphic>
+                  <AnchorPane prefHeight="24.0" prefWidth="21.0">
+                     <children>
+                        <SVGPath content="M 8.50,11.49           C 8.50,11.49 5.50,11.49 5.50,11.49M 7.75,8.49           C 7.75,8.49 5.50,8.49 5.50,8.49M 12.00,5.49           C 12.00,5.49 12.00,20.49 12.00,20.49M 22.00,16.74           C 22.00,16.74 22.00,4.67 22.00,4.67             22.00,3.47 21.02,2.58 19.83,2.68             19.83,2.68 19.77,2.68 19.77,2.68             17.67,2.86 14.48,3.93 12.70,5.05             12.70,5.05 12.53,5.16 12.53,5.16             12.24,5.34 11.76,5.34 11.47,5.16             11.47,5.16 11.22,5.01 11.22,5.01             9.44,3.90 6.26,2.84 4.16,2.67             2.97,2.57 2.00,3.47 2.00,4.66             2.00,4.66 2.00,16.74 2.00,16.74             2.00,17.70 2.78,18.60 3.74,18.72             3.74,18.72 4.03,18.76 4.03,18.76             6.20,19.05 9.55,20.15 11.47,21.20             11.47,21.20 11.51,21.22 11.51,21.22             11.78,21.37 12.21,21.37 12.47,21.22             14.39,20.16 17.75,19.05 19.93,18.76             19.93,18.76 20.26,18.72 20.26,18.72             21.22,18.60 22.00,17.70 22.00,16.74 Z" fill="WHITE" stroke="#898989" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="2.0" styleClass="icon" />
+                     </children>
+                  </AnchorPane>
+               </graphic>
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+            </Button>
+            <Button fx:id="myGroupsBtn" graphicTextGap="10.0" mnemonicParsing="false" onMouseClicked="#myGroupsBtnClick" onMouseEntered="#mouseEnter" onMouseExited="#mouseExit" prefHeight="50.0" prefWidth="200.0" stylesheets="@../../../CSS/button.css" text="My Groups">
+               <font>
+                  <Font size="14.0" />
+               </font>
+               <opaqueInsets>
+                  <Insets />
+               </opaqueInsets>
+               <graphic>
+                  <AnchorPane prefHeight="20.0" prefWidth="20.0">
+                     <children>
+                        <SVGPath content="M 16.16,19.58           C 16.80,19.44 17.39,19.16 17.89,18.75             19.26,17.65 19.26,15.82 17.89,14.71             17.40,14.31 16.81,14.05 16.19,13.89M 3.70,14.43           C 1.58,15.96 1.58,18.46 3.70,19.99             6.12,21.73 10.08,21.73 12.50,19.99             14.63,18.45 14.63,15.95 12.50,14.43             10.09,12.69 6.13,12.69 3.70,14.43 Z           M 14.47,4.42           C 16.17,4.42 17.54,5.91 17.54,7.74             17.54,9.53 16.22,10.99 14.58,11.05             14.51,11.04 14.43,11.04 14.35,11.05M 8.10,10.93           C 8.01,10.92 7.90,10.92 7.81,10.93             5.71,10.85 4.05,9.01 4.05,6.73             4.05,4.41 5.79,2.53 7.96,2.53             10.11,2.53 11.86,4.41 11.86,6.73             11.85,9.01 10.19,10.85 8.10,10.93 Z" fill="WHITE" stroke="#898989" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="2.0" styleClass="icon" />
+                     </children>
+                  </AnchorPane>
+               </graphic>
+            </Button>
+            <Button fx:id="allGroupsBtn" graphicTextGap="10.0" mnemonicParsing="false" onMouseClicked="#allGroupsBtnClick" onMouseEntered="#mouseEnter" onMouseExited="#mouseExit" prefHeight="50.0" prefWidth="200.0" style="-fx-background-color: #a276ff; -fx-text-fill: #ffffff;" stylesheets="@../../../CSS/button.css" text="All Groups">
+               <font>
+                  <Font size="14.0" />
+               </font>
+               <opaqueInsets>
+                  <Insets />
+               </opaqueInsets>
+               <graphic>
+                  <AnchorPane prefHeight="20.0" prefWidth="20.0">
+                     <children>
+                        <SVGPath content="M 7.67,17.38           C 6.49,18.26 6.49,19.69 7.67,20.57             9.01,21.56 11.21,21.56 12.55,20.57             13.73,19.69 13.73,18.26 12.55,17.38             11.22,16.40 9.01,16.40 7.67,17.38 Z           M 10.11,14.45           C 10.06,14.44 10.00,14.44 9.95,14.45             8.79,14.40 7.87,13.35 7.87,12.05             7.87,10.71 8.84,9.64 10.03,9.64             11.23,9.64 12.20,10.72 12.20,12.05             12.19,13.35 11.27,14.41 10.11,14.45 Z           M 5.92,14.27           C 4.77,14.49 3.50,14.26 2.61,13.60             1.43,12.73 1.43,11.29 2.61,10.42             3.51,9.76 4.79,9.53 5.94,9.76M 5.05,7.49           C 5.10,7.48 5.16,7.48 5.21,7.49             6.37,7.45 7.29,6.39 7.29,5.09             7.29,3.76 6.33,2.69 5.13,2.69             3.93,2.69 2.96,3.77 2.96,5.09             2.97,6.39 3.89,7.45 5.05,7.49 Z           M 14.28,14.27           C 15.43,14.49 16.70,14.26 17.58,13.60             18.77,12.73 18.77,11.29 17.58,10.42             16.69,9.76 15.40,9.53 14.25,9.76M 15.14,7.49           C 15.09,7.48 15.03,7.48 14.98,7.49             13.83,7.45 12.90,6.39 12.90,5.09             12.90,3.76 13.87,2.69 15.07,2.69             16.27,2.69 17.23,3.77 17.23,5.09             17.22,6.39 16.30,7.45 15.14,7.49 Z" fill="WHITE" stroke="#a276ff" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="0.8" styleClass="icon" />
+                     </children>
+                  </AnchorPane>
+               </graphic>
+            </Button>
+            <Button fx:id="accountBtn" graphicTextGap="10.0" minHeight="50.0" minWidth="200.0" mnemonicParsing="false" onMouseClicked="#accountBtnClick" onMouseEntered="#mouseEnter" onMouseExited="#mouseExit" stylesheets="@../../../CSS/button.css" text="Account" VBox.vgrow="ALWAYS">
+               <font>
+                  <Font size="16.0" />
+               </font>
+               <opaqueInsets>
+                  <Insets />
+               </opaqueInsets>
+               <graphic>
+                  <AnchorPane prefHeight="24.0" prefWidth="21.0">
+                     <children>
+                        <SVGPath content="M 12.00,8.00           C 10.02,8.00 8.42,9.60 8.42,11.58             8.42,13.56 10.02,15.17 12.00,15.17             13.98,15.17 15.58,13.56 15.58,11.58             15.58,9.60 13.98,8.00 12.00,8.00 Z           M 16.19,2.00           C 16.19,2.00 7.81,2.00 7.81,2.00             4.17,2.00 2.00,4.17 2.00,7.81             2.00,7.81 2.00,16.19 2.00,16.19             2.00,19.00 3.29,20.93 5.56,21.66             6.22,21.89 6.98,22.00 7.81,22.00             7.81,22.00 16.19,22.00 16.19,22.00             17.02,22.00 17.78,21.89 18.44,21.66             20.71,20.93 22.00,19.00 22.00,16.19             22.00,16.19 22.00,7.81 22.00,7.81             22.00,4.17 19.83,2.00 16.19,2.00 Z           M 20.50,16.19           C 20.50,18.33 19.66,19.68 17.97,20.24             17.00,18.33 14.70,16.97 12.00,16.97             9.30,16.97 7.01,18.32 6.03,20.24             6.03,20.24 6.02,20.24 6.02,20.24             4.35,19.70 3.50,18.34 3.50,16.20             3.50,16.20 3.50,7.81 3.50,7.81             3.50,4.99 4.99,3.50 7.81,3.50             7.81,3.50 16.19,3.50 16.19,3.50             19.01,3.50 20.50,4.99 20.50,7.81             20.50,7.81 20.50,16.19 20.50,16.19 Z" fill="#898989" stroke="#898989" strokeLineCap="ROUND" strokeLineJoin="ROUND" styleClass="icon" />
+                     </children>
+                  </AnchorPane>
+               </graphic>
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+            </Button>
+            <Region prefHeight="200.0" prefWidth="200.0" VBox.vgrow="ALWAYS" />
+            <Button fx:id="logOutBtn" alignment="BOTTOM_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="50.0" minWidth="200.0" mnemonicParsing="false" onMouseClicked="#logOutBtnClick" onMouseEntered="#mouseEnter" onMouseExited="#mouseExit" style="-fx-background-color: #a276ff; -fx-text-fill: #ffffff;" text="Log out" textFill="WHITE">
+               <font>
+                  <Font size="20.0" />
+               </font>
+               <VBox.margin>
+                  <Insets bottom="20.0" />
+               </VBox.margin>
+            </Button>
+         </children>
+         <padding>
+            <Insets left="20.0" right="10.0" />
+         </padding>
+         <BorderPane.margin>
+            <Insets right="10.0" />
+         </BorderPane.margin>
+      </VBox>
+   </left>
+   <center>
+      <AnchorPane prefHeight="200.0" prefWidth="200.0" BorderPane.alignment="CENTER">
+         <children>
+            <VBox id="parent" layoutX="32.0" prefHeight="853.0" prefWidth="914.0" AnchorPane.leftAnchor="0.0">
+               <children>
+                  <HBox alignment="CENTER_LEFT">
+                     <children>
+                        <Label fx:id="nameLabel" contentDisplay="BOTTOM" prefHeight="90.0" prefWidth="670.0" text="Welcome, ">
+                           <font>
+                              <Font name="Dubai Medium" size="30.0" />
+                           </font>
+                           <graphic>
+                              <Label fx:id="localTime" alignment="BOTTOM_LEFT" prefHeight="32.0" prefWidth="232.0" text="loading time ..." textFill="#00000099">
+                                 <font>
+                                    <Font name="System Italic" size="14.0" />
+                                 </font>
+                              </Label>
+                           </graphic>
+                        </Label>
+                     </children>
+                     <opaqueInsets>
+                        <Insets />
+                     </opaqueInsets>
+                     <VBox.margin>
+                        <Insets top="30.0" />
+                     </VBox.margin>
+                  </HBox>
+                  <VBox>
+                     <children>
+                        <HBox alignment="CENTER_LEFT" prefHeight="56.0" prefWidth="894.0">
+                           <children>
+                              <Label prefHeight="58.0" prefWidth="276.0" text="Group Detail">
+                                 <font>
+                                    <Font name="Gadugi Bold" size="36.0" />
+                                 </font>
+                                 <padding>
+                                    <Insets bottom="10.0" />
+                                 </padding>
+                              </Label>
+                              <Label fx:id="notiLabel1">
+                                 <HBox.margin>
+                                    <Insets left="10.0" />
+                                 </HBox.margin>
+                                 <font>
+                                    <Font size="16.0" />
+                                 </font>
+                              </Label>
+                           </children>
+                        </HBox>
+                        <HBox alignment="CENTER_LEFT" prefHeight="16.0" prefWidth="894.0">
+                           <children>
+                              <Label text="Group Name: ">
+                                 <font>
+                                    <Font size="20.0" />
+                                 </font>
+                                 <HBox.margin>
+                                    <Insets />
+                                 </HBox.margin>
+                              </Label>
+                              <Label fx:id="groupNameLabel">
+                                 <HBox.margin>
+                                    <Insets left="10.0" />
+                                 </HBox.margin>
+                                 <font>
+                                    <Font size="16.0" />
+                                 </font>
+                              </Label>
+                           </children>
+                           <VBox.margin>
+                              <Insets bottom="10.0" left="20.0" top="54.0" />
+                           </VBox.margin>
+                        </HBox>
+                        <HBox alignment="CENTER_LEFT" prefHeight="16.0" prefWidth="894.0">
+                           <children>
+                              <Label text="Group description: ">
+                                 <font>
+                                    <Font size="20.0" />
+                                 </font>
+                                 <HBox.margin>
+                                    <Insets left="20.0" />
+                                 </HBox.margin>
+                              </Label>
+                              <Label fx:id="groupDescLabel">
+                                 <font>
+                                    <Font size="16.0" />
+                                 </font>
+                                 <HBox.margin>
+                                    <Insets left="10.0" />
+                                 </HBox.margin>
+                              </Label>
+                           </children>
+                           <VBox.margin>
+                              <Insets top="20.0" />
+                           </VBox.margin>
+                        </HBox>
+                     </children>
+                     <VBox.margin>
+                        <Insets bottom="40.0" top="20.0" />
+                     </VBox.margin>
+                  </VBox>
+                  <VBox prefHeight="241.0" prefWidth="894.0">
+                     <children>
+                        <Label prefHeight="35.0" prefWidth="211.0" text="Members in this group">
+                           <font>
+                              <Font name="Gadugi Bold" size="20.0" />
+                           </font>
+                           <padding>
+                              <Insets bottom="10.0" top="20.0" />
+                           </padding>
+                        </Label>
+                        <TableView fx:id="table1" prefHeight="358.0" prefWidth="894.0" stylesheets="@../../../CSS/table_view.css">
+                           <columns>
+                              <TableColumn fx:id="group1" prefWidth="229.86671447753906" text="Username" />
+                              <TableColumn fx:id="category1" prefWidth="165.06671142578125" text="Email" />
+                           </columns>
+                           <columnResizePolicy>
+                              <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                           </columnResizePolicy>
+                        </TableView>
+                     </children>
+                  </VBox>
+               </children>
+               <padding>
+                  <Insets right="20.0" />
+               </padding>
+            </VBox>
+         </children>
+         <padding>
+            <Insets left="20.0" />
+         </padding>
+      </AnchorPane>
+   </center>
+</BorderPane>

--- a/src/main/resources/fxml/main_pages/readonly_note_page.fxml
+++ b/src/main/resources/fxml/main_pages/readonly_note_page.fxml
@@ -138,7 +138,7 @@
                   <Insets bottom="40.0" top="40.0" />
                </VBox.margin>
             </ImageView>
-            <Button fx:id="myNotesBtn" graphicTextGap="10.0" minHeight="50.0" minWidth="200.0" mnemonicParsing="false" onMouseClicked="#myNotesBtnClick" onMouseEntered="#mouseEnter" onMouseExited="#mouseExit" style="-fx-background-color: #a276ff; -fx-text-fill: #ffffff;" stylesheets="@../../CSS/button.css" text="My notes" VBox.vgrow="ALWAYS">
+            <Button fx:id="myNotesBtn" graphicTextGap="10.0" minHeight="50.0" minWidth="200.0" mnemonicParsing="false" onMouseClicked="#myNotesBtnClick" onMouseEntered="#mouseEnter" onMouseExited="#mouseExit" stylesheets="@../../CSS/button.css" text="My notes" VBox.vgrow="ALWAYS">
                <font>
                   <Font size="16.0" />
                </font>
@@ -148,8 +148,8 @@
                <graphic>
                   <AnchorPane prefHeight="24.0" prefWidth="24.0">
                      <children>
-                        <SVGPath content="M12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22Z" fill="WHITE" stroke="#a276ff" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="2.0" styleClass="icon" />
-                        <SVGPath content="M13.5 8C10.47 8 8 10.48 8 13.5C8 14.87 9.12 16 10.5 16C13.52 16 16 13.52 16 10.5C16 9.13 14.87 8 13.5 8Z" fill="WHITE" stroke="#a276ff" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="2.0" styleClass="icon" />
+                        <SVGPath content="M12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22Z" fill="WHITE" stroke="#898989" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="2.0" styleClass="icon" />
+                        <SVGPath content="M13.5 8C10.47 8 8 10.48 8 13.5C8 14.87 9.12 16 10.5 16C13.52 16 16 13.52 16 10.5C16 9.13 14.87 8 13.5 8Z" fill="WHITE" stroke="#898989" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="2.0" styleClass="icon" />
                      </children>
                   </AnchorPane>
                </graphic>
@@ -157,7 +157,7 @@
                   <Insets />
                </VBox.margin>
             </Button>
-            <Button fx:id="shareNotesBtn" graphicTextGap="10.0" minHeight="50.0" minWidth="200.0" mnemonicParsing="false" onMouseClicked="#shareNotesBtnClick" onMouseEntered="#mouseEnter" onMouseExited="#mouseExit" stylesheets="@../../CSS/button.css" text="My Groups' Notes" VBox.vgrow="ALWAYS">
+            <Button fx:id="shareNotesBtn" graphicTextGap="10.0" minHeight="50.0" minWidth="200.0" mnemonicParsing="false" onMouseClicked="#shareNotesBtnClick" onMouseEntered="#mouseEnter" onMouseExited="#mouseExit" style="-fx-background-color: #a276ff; -fx-text-fill: #ffffff;" stylesheets="@../../CSS/button.css" text="My Groups' Notes" VBox.vgrow="ALWAYS">
                <font>
                   <Font size="16.0" />
                </font>
@@ -167,7 +167,7 @@
                <graphic>
                   <AnchorPane prefHeight="24.0" prefWidth="21.0">
                      <children>
-                        <SVGPath content="M 8.50,11.49           C 8.50,11.49 5.50,11.49 5.50,11.49M 7.75,8.49           C 7.75,8.49 5.50,8.49 5.50,8.49M 12.00,5.49           C 12.00,5.49 12.00,20.49 12.00,20.49M 22.00,16.74           C 22.00,16.74 22.00,4.67 22.00,4.67             22.00,3.47 21.02,2.58 19.83,2.68             19.83,2.68 19.77,2.68 19.77,2.68             17.67,2.86 14.48,3.93 12.70,5.05             12.70,5.05 12.53,5.16 12.53,5.16             12.24,5.34 11.76,5.34 11.47,5.16             11.47,5.16 11.22,5.01 11.22,5.01             9.44,3.90 6.26,2.84 4.16,2.67             2.97,2.57 2.00,3.47 2.00,4.66             2.00,4.66 2.00,16.74 2.00,16.74             2.00,17.70 2.78,18.60 3.74,18.72             3.74,18.72 4.03,18.76 4.03,18.76             6.20,19.05 9.55,20.15 11.47,21.20             11.47,21.20 11.51,21.22 11.51,21.22             11.78,21.37 12.21,21.37 12.47,21.22             14.39,20.16 17.75,19.05 19.93,18.76             19.93,18.76 20.26,18.72 20.26,18.72             21.22,18.60 22.00,17.70 22.00,16.74 Z" fill="WHITE" stroke="#898989" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="2.0" styleClass="icon" />
+                        <SVGPath content="M 8.50,11.49           C 8.50,11.49 5.50,11.49 5.50,11.49M 7.75,8.49           C 7.75,8.49 5.50,8.49 5.50,8.49M 12.00,5.49           C 12.00,5.49 12.00,20.49 12.00,20.49M 22.00,16.74           C 22.00,16.74 22.00,4.67 22.00,4.67             22.00,3.47 21.02,2.58 19.83,2.68             19.83,2.68 19.77,2.68 19.77,2.68             17.67,2.86 14.48,3.93 12.70,5.05             12.70,5.05 12.53,5.16 12.53,5.16             12.24,5.34 11.76,5.34 11.47,5.16             11.47,5.16 11.22,5.01 11.22,5.01             9.44,3.90 6.26,2.84 4.16,2.67             2.97,2.57 2.00,3.47 2.00,4.66             2.00,4.66 2.00,16.74 2.00,16.74             2.00,17.70 2.78,18.60 3.74,18.72             3.74,18.72 4.03,18.76 4.03,18.76             6.20,19.05 9.55,20.15 11.47,21.20             11.47,21.20 11.51,21.22 11.51,21.22             11.78,21.37 12.21,21.37 12.47,21.22             14.39,20.16 17.75,19.05 19.93,18.76             19.93,18.76 20.26,18.72 20.26,18.72             21.22,18.60 22.00,17.70 22.00,16.74 Z" fill="WHITE" stroke="#a276ff" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="2.0" styleClass="icon" />
                      </children>
                   </AnchorPane>
                </graphic>


### PR DESCRIPTION
fix the UI bug in the readonly note page, where it does not highlight the my-group-button
<img width="1229" alt="Screenshot 2025-03-19 at 22 18 10" src="https://github.com/user-attachments/assets/279ecf11-9dd3-41ad-9e59-d6fa004a171c" />

add the readonly-group-page.
Now after the user go to my groups page or all-groups-page. there will be a View button on the same row as the group name. After clicking the View buttons, the app will display a new page where the selected group's info is displayed, its name, descrition and user list in the group
my-groups page
<img width="1159" alt="Screenshot 2025-03-19 at 22 13 23" src="https://github.com/user-attachments/assets/bd102e27-b8f3-4b5d-8aa1-cf80ac6214a8" />

all-groups page
<img width="1175" alt="Screenshot 2025-03-19 at 22 13 30" src="https://github.com/user-attachments/assets/e945b10a-485a-4c41-9ea1-c5dbdada142e" />

readonly-group page
<img width="1178" alt="Screenshot 2025-03-19 at 22 16 18" src="https://github.com/user-attachments/assets/035f1419-fe40-48b9-83bd-2c28280faa41" />
