### PR TITLE
update Utils in order to work with backend

### DIFF
--- a/src/main/java/model/ObservableResourceFactory.java
+++ b/src/main/java/model/ObservableResourceFactory.java
@@ -34,6 +34,11 @@ public class ObservableResourceFactory {
     }
 
     public LanguageLabel getSelectedLanguage() {
+        // in case this is a total new app, new user, get default selected language
+        if (selectedLanguage == null){
+            ResourceBundle rb = getResources();
+            return new LanguageLabel("en",rb.getString("en"));
+        }
         return selectedLanguage;
     }
 

--- a/src/main/java/utils/MainPageServices.java
+++ b/src/main/java/utils/MainPageServices.java
@@ -141,7 +141,7 @@ public class MainPageServices {
         // it shuffle between the old format and new format
 
 //        DateFormat currentTime = Utils.getTheCurrentLocaleDateTimeFormatString();
-        System.out.println(timeLabel.getUserData());
+//        System.out.println("time Label"+ timeLabel.getUserData());
         if (timeLabel.getUserData() instanceof Timeline) {
 //            ((Timeline) timeLabel.getUserData()).stop();
             System.out.println("time label is instance of timeline");

--- a/src/main/java/utils/Utils.java
+++ b/src/main/java/utils/Utils.java
@@ -109,7 +109,7 @@ public class Utils {
 
     //    public LanguageLabel[] getSupportedLanguages() {
     public static void getAndSetSupportedLanguages(LanguageLabel[] supportedLanguages, ObservableResourceFactory RESOURCE_FACTORY) {
-        String[] keys = {"english", "finnish", "chinese", "russian"};
+        String[] keys = {"en", "fi", "zh", "ru"};
         ResourceBundle rb = RESOURCE_FACTORY.getResources();
         for (int i = 0; i < keys.length; i++) {
             String key  = keys[i];
@@ -120,10 +120,10 @@ public class Utils {
 
     private static ResourceBundle getResourceBundleFromKey(String key) {
         return switch (key) {
-            case "english"-> ResourceBundle.getBundle("messages", new Locale("en", "US"));
-            case "finnish" -> ResourceBundle.getBundle("messages", new Locale("fi", "FI"));
-            case "chinese" -> ResourceBundle.getBundle("messages", new Locale("zh", "CN"));
-            case "russian" -> ResourceBundle.getBundle("messages", new Locale("ru", "RU"));
+            case "en"-> ResourceBundle.getBundle("messages", new Locale("en", "US"));
+            case "fi" -> ResourceBundle.getBundle("messages", new Locale("fi", "FI"));
+            case "zh" -> ResourceBundle.getBundle("messages", new Locale("zh", "CN"));
+            case "ru" -> ResourceBundle.getBundle("messages", new Locale("ru", "RU"));
             default -> ResourceBundle.getBundle("messages", new Locale("en", "US"));
         };
     }
@@ -146,10 +146,10 @@ public class Utils {
 
         // Rebuild language items with translated labels
         LanguageLabel[] updatedLanguages = {
-                new LanguageLabel("english", rb.getString("english")),
-                new LanguageLabel("finnish", rb.getString("finnish")),
-                new LanguageLabel("chinese", rb.getString("chinese")),
-                new LanguageLabel("russian", rb.getString("russian"))
+                new LanguageLabel("en", rb.getString("en")),
+                new LanguageLabel("fi", rb.getString("fi")),
+                new LanguageLabel("zh", rb.getString("zh")),
+                new LanguageLabel("ru", rb.getString("ru"))
         };
 
         // Temporarily remove event handler to avoid recursion
@@ -188,9 +188,9 @@ public class Utils {
         } else if (preservedLabel != null) {
             return preservedLabel.getKey();
         } else {
-            return "english";
+            return "en";
         }
-//        return selected != null ? selected.getKey() : preservedLabel != null ? preservedLabel.getKey() : "english";
+//        return selected != null ? selected.getKey() : preservedLabel != null ? preservedLabel.getKey() : "en";
     }
     public static String getselectedLanguageKey(LanguageLabel preservedLabel){
         String selectedLanguageKey =  getSelectedLanguageKey(null, preservedLabel);

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -1,8 +1,8 @@
 # Languages
-english=English
-finnish= Suomi
-russian = русский
-chinese = 汉语
+en=English
+fi= Suomi
+ru = русский
+zh = 汉语
 changeLanguageLabel=Change Your Language
 
 # Sidebar

--- a/src/main/resources/messages_fi_FI.properties
+++ b/src/main/resources/messages_fi_FI.properties
@@ -1,8 +1,8 @@
 # Languages
-english=English
-finnish= Suomi
-russian = русский
-chinese = 汉语
+en=English
+fi= Suomi
+ru = русский
+zh = 汉语
 changeLanguageLabel=Muuta kieli
 
 # Sidebar

--- a/src/main/resources/messages_ru_RU.properties
+++ b/src/main/resources/messages_ru_RU.properties
@@ -1,8 +1,8 @@
 # Languages
-english=English
-finnish= Suomi
-russian = русский
-chinese = 汉语
+en=English
+fi= Suomi
+ru = русский
+zh = 汉语
 changeLanguageLabel=Изменить язык
 
 

--- a/src/main/resources/messages_zh_CN.properties
+++ b/src/main/resources/messages_zh_CN.properties
@@ -1,8 +1,8 @@
 # Languages
-english=English
-finnish= Suomi
-russian = русский
-chinese = 汉语
+en=English
+fi= Suomi
+ru = русский
+zh = 汉语
 changeLanguageLabel=更改语言
 
 # Sidebar


### PR DESCRIPTION
Since backend use the languageKey as: en,fi,ru,zh.
The old version of FE localization languageKey is english, finnish, russian, chinese.

Change the FE key to be the same as backend's database. 

In Hello View Page, handle the case when there is no SelectedLanuageKey available when the app just start.

TODO:
need to save the user's preference languageKey when user choose to the Preference ( application setting). So that when a user close the application as reopen the app, he will be shown with his preference language.