### PR TITLE
Add language support from BE for login and registration

### DIFF
--- a/src/main/java/controller/auth/LogInController.java
+++ b/src/main/java/controller/auth/LogInController.java
@@ -272,6 +272,8 @@ public class LogInController extends PageController {
         HttpRequestBuilder httpRequest = new HttpRequestBuilder("POST", URI);
         httpRequest.updateJsonRequest("username", username);
         httpRequest.updateJsonRequest("password", password);
+        String languageCode = RESOURCE_FACTORY.getResources().getLocale().getLanguage();
+        httpRequest.addHeader("Accept-Language", languageCode);
         httpRequest.setRequestBody();
         HttpPost httpPost = (HttpPost) httpRequest.getHttpRequest();
         CloseableHttpClient httpClient = httpRequest.getHttpClient();
@@ -291,6 +293,8 @@ public class LogInController extends PageController {
                 TokenStorage.saveToken(username, token);
                 String savedUsername = TokenStorage.getUser();
                 String savedToken = TokenStorage.getToken();
+                String languageCode = (String) object.get("languageCode");
+                ObservableResourceFactory.getInstance().changeLanguage(languageCode);
                 goToMainPage();
 
             } catch (JSONException e) {

--- a/src/main/java/model/HttpRequestBuilder.java
+++ b/src/main/java/model/HttpRequestBuilder.java
@@ -84,6 +84,10 @@ public class HttpRequestBuilder {
         this.jsonRequest = jsonObject;
     }
 
+    public void addHeader(String name, String value) {
+        httpRequest.addHeader(name, value);
+    }
+
     public void setRequestBody() throws UnsupportedEncodingException {
         if (!this.methodName.equals("GET") && !this.methodName.equals("DELETE")) {
             this.stringEntity = new StringEntity(this.jsonRequest.toString());

--- a/src/main/java/model/ObservableResourceFactory.java
+++ b/src/main/java/model/ObservableResourceFactory.java
@@ -80,4 +80,28 @@ public class ObservableResourceFactory {
         return ResourceBundle.getBundle("messages", locale);
     }
 
+    public void changeLanguage(String key) {
+        Locale locale;
+
+        switch (key.toLowerCase()) {
+            case "chinese":
+            case "zh":
+                locale = new Locale("zh", "CN");
+                break;
+            case "finnish":
+            case "fi":
+                locale = new Locale("fi", "FI");
+                break;
+            case "russian":
+            case "ru":
+                locale = new Locale("ru", "RU");
+                break;
+            default:
+                locale = new Locale("en", "US");
+                break;
+        }
+
+        ResourceBundle newBundle = ResourceBundle.getBundle("messages", locale);
+        setResources(newBundle);
+    }
 }


### PR DESCRIPTION
This pull request has 2 features for FE:

1. When a user login, BE provides "languageCode" in LoginResponce (see pull request in BE), FE coverts the provided "languageCode" into Locale (ObservableResourceFactory.java - lines 83-106) and sets it as the current interface language (LogInController.java - lines 296-297).

2. When user login, FE request provides language in the header (key: "Accept-Language") (LogInController.java - lines 275-276) in order that BE localize error messages in this language. The register request doesn't require the language in the header, though because it is already provided in the body, so I decided not to duplicate the language in body and header.